### PR TITLE
Allow subclasses use sharedInstance

### DIFF
--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -186,7 +186,7 @@ static NSString *kSmileSettingNaviID = @"smileSettingsNavi";
     static id sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[SmileAuthenticator alloc] init];
+        sharedInstance = [[self alloc] init];
     });
     
     return sharedInstance;

--- a/SmileTouchID.podspec
+++ b/SmileTouchID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SmileTouchID"
-  s.version      = "0.0.6"
+  s.version      = "0.0.7"
   s.summary      = "A Library for configure Touch ID & passcode conveniently"
   s.description  = <<-DESC
                    1. Handle all complicated things about Touch ID & Passcode. You just need to write a few simple code to integrate Touch ID & Passcode to your app.
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
   s.source_files  = 'SmileAuth/Classes/*'
   s.public_header_files = 'SmileAuth/Classes/*.h'
   s.resource = ['SmileAuth/Assets/*']
-  s.frameworks = 'UIKit'
-  s.weak_framework = 'LocalAuthentication'
+  s.frameworks = 'UIKit', 'LocalAuthentication'
 
 end


### PR DESCRIPTION
Hi @liu044100 

Another quick fix to allow subclasses use sharedInstance.
I updated the podfile to 0.0.7 (remember to create the tag and don't remember the old tags, not necessary). I also change LocalAuthentication framework from weak_framework to framework because in Xcode 7 cause a warning.

Really nice library, works better than [VENTouchLock](https://github.com/venmo/VENTouchLock)! ;)
