### PR TITLE
Added logout method

### DIFF
--- a/SmileAuth/Classes/SmileAuthenticator.h
+++ b/SmileAuth/Classes/SmileAuthenticator.h
@@ -67,6 +67,9 @@ typedef NS_ENUM(int, SecurityType) {
 +(BOOL)isSamePassword:(NSString *)userInput;
 +(void)clearPassword;
 
+/// reset the authenticated property, without clearing password : next time you ask for presentAuthViewController, it will show the password event if it was already entered correctly seconds ago. (allowing you to protect for example just a part of an app)
+-(void)logout;
+
 -(void)userSetPassword:(NSString*)newPassword;
 -(void)authenticateWithSuccess:(AuthCompletionBlock) authSuccessBlock andFailure:(AuthErrorBlock) failureBlock;
 

--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -304,4 +304,9 @@ static NSString *kSmileSettingNaviID = @"smileSettingsNavi";
     [[SmileAuthenticator sharedInstance].keychainWrapper writeToKeychain];
 }
 
+-(void)logout{
+    _isAuthenticated = NO;
+    _didReturnFromBackground = NO;
+}
+
 @end

--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -95,7 +95,7 @@ static NSString *kSmileSettingNaviID = @"smileSettingsNavi";
         _isAuthenticated = NO;
     }
     
-    if (!_isAuthenticated) {
+    if (!_isAuthenticated && !_isShowLogin) {
         
         BOOL isAnimated = YES;
         


### PR DESCRIPTION
The logout method allows to programmatically set the user as if he
didn’t enter his password: this let to the programmer the option to
protect a part of the app, and each time the user tries to access it,
he is presented the passcode view controller (by calling logout before
presentviewcontroller…)
