### PR TITLE
[Improvement] Checks whether user was authenticated before background

### DIFF
--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -143,7 +143,7 @@ static NSString *kSmileSettingNaviID = @"smileSettingsNavi";
 }
 
 -(void)appDidEnterBackground:(NSNotification*)notification{
-    if _isAuthenticated {
+    if (_isAuthenticated) {
         _didReturnFromBackground = YES;
         _isAuthenticated = NO;
     }

--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -143,8 +143,10 @@ static NSString *kSmileSettingNaviID = @"smileSettingsNavi";
 }
 
 -(void)appDidEnterBackground:(NSNotification*)notification{
-    _isAuthenticated = NO;
-    _didReturnFromBackground = YES;
+    if _isAuthenticated {
+        _didReturnFromBackground = YES;
+        _isAuthenticated = NO;
+    }
 }
 
 -(void)appWillEnterForeground:(NSNotification*)notification{  


### PR DESCRIPTION
This way, it only prompts the user for authentication if she was already authenticated.

If the user hasn't been prompted for auth before, it doesn't make sense asking just because she returns to the app.
