### PR TITLE
Add timeout interval property for show password or touch ID UI again.

### DIFF
--- a/Example/TouchID/AppDelegate.m
+++ b/Example/TouchID/AppDelegate.m
@@ -32,6 +32,7 @@
     [SmileAuthenticator sharedInstance].appLogoName = @"my_Logo";
     [SmileAuthenticator sharedInstance].navibarTranslucent = YES;
     [SmileAuthenticator sharedInstance].backgroundImage = [UIImage imageNamed:kBG_Image];
+    //[SmileAuthenticator sharedInstance].timeoutInterval = 10;
     
     return YES;
 }

--- a/SmileAuth/Classes/SmileAuthenticator.h
+++ b/SmileAuth/Classes/SmileAuthenticator.h
@@ -67,6 +67,8 @@ typedef NS_ENUM(int, SecurityType) {
 @property (nonatomic) BOOL nightMode;
 /*!@brief <b>For customization</b>, if set it to Yes, add parallax effect to password circle views, the default value is Yes.*/
 @property (nonatomic) BOOL parallaxMode;
+/*!@brief  The timeout interval, in seconds, for show password or touch ID UI again. The default timeout interval is 0 seconds, it means password or touch ID will be showed immediately. */
+@property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
 +(SmileAuthenticator*)sharedInstance;
 + (BOOL)canAuthenticateWithError:(NSError **) error;

--- a/SmileAuth/Classes/SmileAuthenticator.m
+++ b/SmileAuth/Classes/SmileAuthenticator.m
@@ -22,6 +22,7 @@ static NSString *kStoryBoardName = @"SmileSettingVC";
 @property (nonatomic, readwrite) BOOL isShowingAuthVC;
 @property (nonatomic, readwrite) BOOL isAuthenticated;
 @property (nonatomic, strong) UIViewController *previousPresentedVC;
+@property (nonatomic, strong) NSDate *previousAuthenticatedDate;
 
 @end
 
@@ -60,6 +61,7 @@ static NSString *kStoryBoardName = @"SmileSettingVC";
 #pragma mark - for Delegate
 
 -(void)touchID_OR_PasswordAuthSuccess{
+    self.previousAuthenticatedDate = [NSDate date];
     if ([self.delegate respondsToSelector:@selector(userSuccessAuthentication)]) {
         [self.delegate userSuccessAuthentication];
     }
@@ -93,6 +95,11 @@ static NSString *kStoryBoardName = @"SmileSettingVC";
     
     if (self.securityType != INPUT_TOUCHID) {
         _isAuthenticated = NO;
+    } else {
+        if (self.previousAuthenticatedDate && !_isAuthenticated) {
+            NSTimeInterval intervalSincePreviousAuthenticated = fabs(self.previousAuthenticatedDate.timeIntervalSinceNow);
+            _isAuthenticated = (intervalSincePreviousAuthenticated < self.timeoutInterval);
+        }
     }
     
     if (!_isAuthenticated) {
@@ -180,6 +187,7 @@ static NSString *kStoryBoardName = @"SmileSettingVC";
         self.securityType = INPUT_TWICE;
         self.parallaxMode = YES;
         self.passcodeDigit = kPasswordLength;
+        self.timeoutInterval = 0;
         
         [self configureNotification];
     }

--- a/SmileAuth/Classes/SmilePasswordContainerView.m
+++ b/SmileAuth/Classes/SmilePasswordContainerView.m
@@ -13,17 +13,7 @@
 
 @end
 
-@implementation SmilePasswordContainerView {
-
-}
-
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
-}
-*/
+@implementation SmilePasswordContainerView
 
 -(void)configureAndAddSmilePasswordView{
     

--- a/SmileAuth/Classes/SmilePasswordView.m
+++ b/SmileAuth/Classes/SmilePasswordView.m
@@ -27,14 +27,6 @@ static CGFloat kMAX_RadiusConst = 32.0;
     NSInteger _shakeCount;
 }
 
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
-}
-*/
-
 - (void)drawRect:(CGRect)rect
 {
     [super drawRect:rect];

--- a/SmileAuth/Classes/SmileSettingVC.m
+++ b/SmileAuth/Classes/SmileSettingVC.m
@@ -449,15 +449,4 @@
     [aView addMotionEffect:group] ;
 }
 
-
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 @end

--- a/SmileTouchID.podspec
+++ b/SmileTouchID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SmileTouchID"
-  s.version      = "0.1.6"
+  s.version      = "0.1.7"
   s.summary      = "A Library for configure Touch ID & passcode conveniently"
   s.description  = <<-DESC
                    1. Handle all complicated things about Touch ID & Passcode. You just need to write a few simple code to integrate Touch ID & Passcode to your app.


### PR DESCRIPTION
As #18 issues mentioned.

Add the new property `NSTimeInterval timeoutInterval` in the class`SmileAuthenticator`. This property is the timeout interval, in seconds, for show password or touch ID UI again. The default timeout interval is 0 seconds, it means password or touch ID will be showed immediately.
